### PR TITLE
Applying the Apache 2.0 License agreement header

### DIFF
--- a/applications/Simple/kubernetes.yml
+++ b/applications/Simple/kubernetes.yml
@@ -1,5 +1,12 @@
-# Copyright (c) 2017 Software AG, Darmstadt, Germany and/or Software AG USA Inc., Reston, VA, USA, and/or its subsidiaries and/or its affiliates and/or their licensors.
-# Use, reproduction, transfer, publication or disclosure is prohibited except as specifically provided for in your License Agreement with Software AG
+# Copyright (c) 2017 Software AG, Darmstadt, Germany and/or its licensors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this 
+# file except in compliance with the License. You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+# either express or implied. 
+# See the License for the specific language governing permissions and limitations under the License.
 
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
Replacing the standard SAG commercial license header with the Apache 2.0 license header